### PR TITLE
Bag -> MutableBag; ImmutableBag -> Bag

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -222,6 +222,10 @@ class Arr
                     $current[$key] = $value;
                 }
             } elseif (isset($current[$key])) {
+                if ($current instanceof Bag) {
+                    Deprecated::warn('Mutating items in a ' . Bag::class, 1.1, 'Use a ' . MutableBag::class . ' instead.');
+                }
+
                 $current = &$current[$key];
             } elseif (!static::canReturnArraysByReference($current)) {
                 throw new RuntimeException(
@@ -234,6 +238,10 @@ class Arr
                     )
                 );
             } else {
+                if ($current instanceof Bag) {
+                    Deprecated::warn('Mutating items in a ' . Bag::class, 1.1, 'Use a ' . MutableBag::class . ' instead.');
+                }
+
                 $current[$key] = [];
                 $current = &$current[$key];
             }

--- a/src/ImmutableBag.php
+++ b/src/ImmutableBag.php
@@ -4,6 +4,7 @@ namespace Bolt\Collection;
 
 use ArrayAccess;
 use BadMethodCallException;
+use Bolt\Common\Deprecated;
 use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
@@ -18,6 +19,8 @@ use Traversable;
  * But there are no methods that allow the object to be mutated. All methods return a new bag.
  *
  * @author Carson Full <carsonfull@gmail.com>
+ *
+ * @deprecated since 1.1 and will be removed in 2.0. Use {@see Bag} instead.
  */
 class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
 {
@@ -33,6 +36,8 @@ class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSer
      */
     public function __construct(array $items = [])
     {
+        Deprecated::method(1.1, Bag::class);
+
         $this->items = $items;
     }
 
@@ -364,21 +369,21 @@ class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSer
     /**
      * Returns a mutable bag with the items from this bag.
      *
-     * @return Bag
+     * @return MutableBag
      */
     public function mutable()
     {
-        return new Bag($this->items);
+        return new MutableBag($this->items);
     }
 
     /**
      * Returns an immutable bag with the items from this bag.
      *
-     * @return ImmutableBag
+     * @return Bag
      */
     public function immutable()
     {
-        return new self($this->items);
+        return new Bag($this->items);
     }
 
     /**

--- a/src/MutableBag.php
+++ b/src/MutableBag.php
@@ -2,45 +2,25 @@
 
 namespace Bolt\Collection;
 
-use Bolt\Common\Deprecated;
-
 /**
  * This is an OO implementation of almost all of PHP's array functionality.
  *
- * All methods that allow mutation are deprecated, use {@see MutableBag} for those cases instead.
+ * Generally only methods dealing with a single item mutate the current bag,
+ * all others return a new bag.
  *
  * @author Carson Full <carsonfull@gmail.com>
  */
-class Bag extends ImmutableBag
+class MutableBag extends Bag
 {
-    // region Creation / Unwrapping Methods
-
-    /**
-     * Constructor.
-     *
-     * @param array $items
-     */
-    public function __construct(array $items = [])
-    {
-        // Don't call parent to avoid deprecation warning.
-        $this->items = $items;
-    }
-
-    // endregion
-
-    // region Mutating Methods (Deprecated)
+    // region Mutating Methods
 
     /**
      * Adds an item to the end of this bag.
      *
      * @param mixed $item The item to append
-     *
-     * @deprecated since 1.1 and will be removed in 2.0. Use {@see MutableBag} instead.
      */
     public function add($item)
     {
-        Deprecated::method(1.1, MutableBag::class);
-
         $this->items[] = $item;
     }
 
@@ -48,13 +28,9 @@ class Bag extends ImmutableBag
      * Adds an item to the beginning of this bag.
      *
      * @param mixed $item The item to prepend
-     *
-     * @deprecated since 1.1 and will be removed in 2.0. Use {@see MutableBag} instead.
      */
     public function prepend($item)
     {
-        Deprecated::method(1.1, MutableBag::class);
-
         array_unshift($this->items, $item);
     }
 
@@ -63,13 +39,9 @@ class Bag extends ImmutableBag
      *
      * @param string $key   The key
      * @param mixed  $value The value
-     *
-     * @deprecated since 1.1 and will be removed in 2.0. Use {@see MutableBag} instead.
      */
     public function set($key, $value)
     {
-        Deprecated::method(1.1, MutableBag::class);
-
         $this->items[$key] = $value;
     }
 
@@ -97,25 +69,17 @@ class Bag extends ImmutableBag
      *
      * @param string $path  The path to traverse and set the value at
      * @param mixed  $value The value to set
-     *
-     * @deprecated since 1.1 and will be removed in 2.0. Use {@see MutableBag} instead.
      */
     public function setPath($path, $value)
     {
-        Deprecated::method(1.1, MutableBag::class);
-
         Arr::set($this->items, $path, $value);
     }
 
     /**
      * Remove all items from bag.
-     *
-     * @deprecated since 1.1 and will be removed in 2.0. Use {@see MutableBag} instead.
      */
     public function clear()
     {
-        Deprecated::method(1.1, MutableBag::class);
-
         $this->items = [];
     }
 
@@ -126,13 +90,9 @@ class Bag extends ImmutableBag
      * @param mixed|null $default The default value to return if the key is not found
      *
      * @return mixed The removed item or default, if the bag did not contain the item
-     *
-     * @deprecated since 1.1 and will be removed in 2.0. Use {@see MutableBag} instead.
      */
     public function remove($key, $default = null)
     {
-        Deprecated::method(1.1, MutableBag::class);
-
         if (!$this->has($key)) {
             return $default;
         }
@@ -147,13 +107,9 @@ class Bag extends ImmutableBag
      * Removes the given item from the bag if it is found.
      *
      * @param mixed $item
-     *
-     * @deprecated since 1.1 and will be removed in 2.0. Use {@see MutableBag} instead.
      */
     public function removeItem($item)
     {
-        Deprecated::method(1.1, MutableBag::class);
-
         $key = array_search($item, $this->items, true);
 
         if ($key !== false) {
@@ -165,13 +121,9 @@ class Bag extends ImmutableBag
      * Removes and returns the first item in the list.
      *
      * @return mixed|null
-     *
-     * @deprecated since 1.1 and will be removed in 2.0. Use {@see MutableBag} instead.
      */
     public function removeFirst()
     {
-        Deprecated::method(1.1, MutableBag::class);
-
         return array_shift($this->items);
     }
 
@@ -179,13 +131,9 @@ class Bag extends ImmutableBag
      * Removes and returns the last item in the list.
      *
      * @return mixed|null
-     *
-     * @deprecated since 1.1 and will be removed in 2.0. Use {@see MutableBag} instead.
      */
     public function removeLast()
     {
-        Deprecated::method(1.1, MutableBag::class);
-
         return array_pop($this->items);
     }
 
@@ -202,8 +150,6 @@ class Bag extends ImmutableBag
      */
     public function &offsetGet($offset)
     {
-        // Returning values by reference is deprecated, but we have no way of knowing here.
-
         $result = null;
         if (isset($this->items[$offset])) {
             $result = &$this->items[$offset];
@@ -221,12 +167,10 @@ class Bag extends ImmutableBag
      */
     public function offsetSet($offset, $value)
     {
-        Deprecated::method(1.1, MutableBag::class);
-
         if ($offset === null) {
-            $this->items[] = $value;
+            $this->add($value);
         } else {
-            $this->items[$offset] = $value;
+            $this->set($offset, $value);
         }
     }
 
@@ -239,9 +183,7 @@ class Bag extends ImmutableBag
      */
     public function offsetUnset($offset)
     {
-        Deprecated::method(1.1, MutableBag::class);
-
-        unset($this->items[$offset]);
+        $this->remove($offset);
     }
 
     // endregion

--- a/tests/BagTest.php
+++ b/tests/BagTest.php
@@ -15,6 +15,11 @@ class BagTest extends ImmutableBagTest
         return new Bag($items);
     }
 
+    // region Mutating Methods (Deprecated)
+
+    /**
+     * @group legacy
+     */
     public function testAdd()
     {
         $bag = $this->createBag();
@@ -25,6 +30,9 @@ class BagTest extends ImmutableBagTest
         $this->assertEquals(['foo', 'bar'], $bag->toArray());
     }
 
+    /**
+     * @group legacy
+     */
     public function testPrepend()
     {
         $bag = $this->createBag();
@@ -35,6 +43,9 @@ class BagTest extends ImmutableBagTest
         $this->assertEquals(['bar', 'foo'], $bag->toArray());
     }
 
+    /**
+     * @group legacy
+     */
     public function testSet()
     {
         $bag = $this->createBag();
@@ -44,6 +55,9 @@ class BagTest extends ImmutableBagTest
         $this->assertEquals(['foo' => 'bar'], $bag->toArray());
     }
 
+    /**
+     * @group legacy
+     */
     public function testSetPath()
     {
         $bag = $this->createBag([
@@ -61,6 +75,9 @@ class BagTest extends ImmutableBagTest
         $this->assertEquals(['red', 'blue'], $bag->getPath('items/colors'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testClear()
     {
         $bag = $this->createBag(['foo', 'bar']);
@@ -70,6 +87,9 @@ class BagTest extends ImmutableBagTest
         $this->assertTrue($bag->isEmpty());
     }
 
+    /**
+     * @group legacy
+     */
     public function testRemove()
     {
         $bag = $this->createBag(['foo' => 'bar']);
@@ -81,6 +101,9 @@ class BagTest extends ImmutableBagTest
         $this->assertEquals('default', $bag->remove('derp', 'default'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testRemoveItem()
     {
         $bag = $this->createBag(['foo', 'bar']);
@@ -90,6 +113,9 @@ class BagTest extends ImmutableBagTest
         $this->assertFalse($bag->hasItem('bar'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testRemoveFirst()
     {
         $bag = $this->createBag(['foo', 'bar']);
@@ -100,6 +126,9 @@ class BagTest extends ImmutableBagTest
         $this->assertTrue($bag->isEmpty());
     }
 
+    /**
+     * @group legacy
+     */
     public function testRemoveLast()
     {
         $bag = $this->createBag(['foo', 'bar']);
@@ -110,8 +139,13 @@ class BagTest extends ImmutableBagTest
         $this->assertTrue($bag->isEmpty());
     }
 
+    // endregion
+
     // region Internal Methods
 
+    /**
+     * @group legacy
+     */
     public function testOffsetGet()
     {
         $bag = $this->createBag(['foo' => 'bar']);
@@ -120,6 +154,9 @@ class BagTest extends ImmutableBagTest
         $this->assertNull($bag['nope']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testOffsetGetByReference()
     {
         $bag = $this->createBag(['arr' => ['1']]);
@@ -139,6 +176,9 @@ class BagTest extends ImmutableBagTest
         $this->assertEquals(['1', '2'], $bag['arr']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testOffsetSet()
     {
         $bag = $this->createBag();
@@ -152,6 +192,9 @@ class BagTest extends ImmutableBagTest
         $this->assertEquals('world', $bag[1]);
     }
 
+    /**
+     * @group legacy
+     */
     public function testOffsetUnset()
     {
         $bag = $this->createBag(['foo' => 'bar']);

--- a/tests/BagTest.php
+++ b/tests/BagTest.php
@@ -4,13 +4,20 @@ namespace Bolt\Collection\Tests;
 
 use ArrayObject;
 use Bolt\Collection\Bag;
-use PHPUnit_Framework_TestCase as TestCase;
 
-class BagTest extends TestCase
+class BagTest extends ImmutableBagTest
 {
+    /** @var string|Bag */
+    protected $cls = Bag::class;
+
+    protected function createBag($items = [])
+    {
+        return new Bag($items);
+    }
+
     public function testAdd()
     {
-        $bag = new Bag();
+        $bag = $this->createBag();
 
         $bag->add('foo');
         $bag->add('bar');
@@ -20,7 +27,7 @@ class BagTest extends TestCase
 
     public function testPrepend()
     {
-        $bag = new Bag();
+        $bag = $this->createBag();
 
         $bag->prepend('foo');
         $bag->prepend('bar');
@@ -30,7 +37,7 @@ class BagTest extends TestCase
 
     public function testSet()
     {
-        $bag = new Bag();
+        $bag = $this->createBag();
 
         $bag->set('foo', 'bar');
 
@@ -39,7 +46,7 @@ class BagTest extends TestCase
 
     public function testSetPath()
     {
-        $bag = new Bag([
+        $bag = $this->createBag([
             'items' => new ArrayObject([
                 'foo' => 'bar',
             ]),
@@ -56,7 +63,7 @@ class BagTest extends TestCase
 
     public function testClear()
     {
-        $bag = new Bag(['foo', 'bar']);
+        $bag = $this->createBag(['foo', 'bar']);
 
         $bag->clear();
 
@@ -65,7 +72,7 @@ class BagTest extends TestCase
 
     public function testRemove()
     {
-        $bag = new Bag(['foo' => 'bar']);
+        $bag = $this->createBag(['foo' => 'bar']);
 
         $this->assertEquals('bar', $bag->remove('foo'));
         $this->assertFalse($bag->has('foo'));
@@ -76,7 +83,7 @@ class BagTest extends TestCase
 
     public function testRemoveItem()
     {
-        $bag = new Bag(['foo', 'bar']);
+        $bag = $this->createBag(['foo', 'bar']);
 
         $bag->removeItem('bar');
 
@@ -85,7 +92,7 @@ class BagTest extends TestCase
 
     public function testRemoveFirst()
     {
-        $bag = new Bag(['foo', 'bar']);
+        $bag = $this->createBag(['foo', 'bar']);
 
         $this->assertEquals('foo', $bag->removeFirst());
         $this->assertEquals('bar', $bag->removeFirst());
@@ -95,11 +102,11 @@ class BagTest extends TestCase
 
     public function testRemoveLast()
     {
-        $bag = new Bag(['foo', 'bar']);
+        $bag = $this->createBag(['foo', 'bar']);
 
         $this->assertEquals('bar', $bag->removeLast());
         $this->assertEquals('foo', $bag->removeLast());
-        $this->assertNull($bag->removeFirst());
+        $this->assertNull($bag->removeLast());
         $this->assertTrue($bag->isEmpty());
     }
 
@@ -107,15 +114,15 @@ class BagTest extends TestCase
 
     public function testOffsetGet()
     {
-        $bag = new Bag(['foo' => 'bar']);
+        $bag = $this->createBag(['foo' => 'bar']);
 
         $this->assertEquals('bar', $bag['foo']);
         $this->assertNull($bag['nope']);
     }
 
-    public function testOffsetGetModifyByReference()
+    public function testOffsetGetByReference()
     {
-        $bag = new Bag(['arr' => ['1']]);
+        $bag = $this->createBag(['arr' => ['1']]);
 
         // Assert arrays are not able to be modified by reference.
         $errors = new \ArrayObject();
@@ -134,7 +141,7 @@ class BagTest extends TestCase
 
     public function testOffsetSet()
     {
-        $bag = new Bag();
+        $bag = $this->createBag();
 
         $bag['foo'] = 'bar';
         $bag[] = 'hello';
@@ -147,7 +154,7 @@ class BagTest extends TestCase
 
     public function testOffsetUnset()
     {
-        $bag = new Bag(['foo' => 'bar']);
+        $bag = $this->createBag(['foo' => 'bar']);
 
         unset($bag['foo']);
 

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -5,16 +5,24 @@ namespace Bolt\Collection\Tests;
 use ArrayObject;
 use Bolt\Collection\Bag;
 use Bolt\Collection\ImmutableBag;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class ImmutableBagTest extends TestCase
 {
+    /** @var string|ImmutableBag class used for static creation methods and instance of assertions */
+    protected $cls = ImmutableBag::class;
+
+    protected function createBag($items = [])
+    {
+        return new ImmutableBag($items);
+    }
+
     // region Creation / Unwrapping Methods
 
     public function provideFromAndToArray()
     {
         return [
-            'bag'         => [new ImmutableBag(['foo' => 'bar'])],
+            'bag'         => [$this->createBag(['foo' => 'bar'])],
             'traversable' => [new ArrayObject(['foo' => 'bar'])],
             'null'        => [null, []],
             'stdClass'    => [json_decode(json_encode(['foo' => 'bar']))],
@@ -31,7 +39,8 @@ class ImmutableBagTest extends TestCase
      */
     public function testFromAndToArray($input, $output = ['foo' => 'bar'])
     {
-        $actual = ImmutableBag::from($input)->toArray();
+        $cls = $this->cls;
+        $actual = $cls::from($input)->toArray();
         $this->assertSame($output, $actual);
     }
 
@@ -45,17 +54,18 @@ class ImmutableBagTest extends TestCase
             ])),
         ];
 
-        $bag = ImmutableBag::fromRecursive($a);
+        $cls = $this->cls;
+        $bag = $cls::fromRecursive($a);
 
         $bagArr = $bag->toArray();
         $this->assertEquals('bar', $bagArr['foo']);
 
-        $this->assertInstanceOf(ImmutableBag::class, $bagArr['items']);
+        $this->assertInstanceOf($cls, $bagArr['items']);
         /** @var ImmutableBag $items */
         $items = $bagArr['items'];
         $this->assertEquals(['hello' => 'world'], $items->toArray());
 
-        $this->assertInstanceOf(ImmutableBag::class, $bagArr['std class']);
+        $this->assertInstanceOf($cls, $bagArr['std class']);
         /** @var ImmutableBag $stdClass */
         $stdClass = $bagArr['std class'];
         $this->assertEquals(['why use' => 'these'], $stdClass->toArray());
@@ -63,9 +73,9 @@ class ImmutableBagTest extends TestCase
 
     public function testToArrayRecursive()
     {
-        $bag = new ImmutableBag([
+        $bag = $this->createBag([
             'foo'    => 'bar',
-            'colors' => new ImmutableBag(['red', 'blue']),
+            'colors' => $this->createBag(['red', 'blue']),
             'array'  => ['hello', 'world'],
         ]);
         $expected = [
@@ -81,7 +91,8 @@ class ImmutableBagTest extends TestCase
 
     public function testCombine()
     {
-        $actual = ImmutableBag::combine(['red', 'green'], ['bad', 'good'])->toArray();
+        $cls = $this->cls;
+        $actual = $cls::combine(['red', 'green'], ['bad', 'good'])->toArray();
         $expected = [
             'red'   => 'bad',
             'green' => 'good',
@@ -92,7 +103,8 @@ class ImmutableBagTest extends TestCase
 
     public function testCombineEmpty()
     {
-        $actual = ImmutableBag::combine([], [])->toArray();
+        $cls = $this->cls;
+        $actual = $cls::combine([], [])->toArray();
 
         $this->assertEquals([], $actual);
     }
@@ -102,7 +114,8 @@ class ImmutableBagTest extends TestCase
      */
     public function testCombineDifferentSizes()
     {
-        ImmutableBag::combine(['derp'], ['wait', 'wut']);
+        $cls = $this->cls;
+        $cls::combine(['derp'], ['wait', 'wut']);
     }
 
     // endregion
@@ -111,7 +124,7 @@ class ImmutableBagTest extends TestCase
 
     public function testHas()
     {
-        $bag = new ImmutableBag(['foo' => 'bar', 'null' => null]);
+        $bag = $this->createBag(['foo' => 'bar', 'null' => null]);
 
         $this->assertTrue($bag->has('foo'));
         $this->assertTrue($bag->has('null'));
@@ -121,7 +134,7 @@ class ImmutableBagTest extends TestCase
 
     public function testHasPath()
     {
-        $bag = new ImmutableBag([
+        $bag = $this->createBag([
             'items' => new ArrayObject([
                 'foo' => 'bar',
             ]),
@@ -136,7 +149,7 @@ class ImmutableBagTest extends TestCase
     public function testHasItem()
     {
         $foo = new ArrayObject();
-        $bag = new ImmutableBag([
+        $bag = $this->createBag([
             'foo'   => 'bar',
             'items' => $foo,
         ]);
@@ -149,7 +162,7 @@ class ImmutableBagTest extends TestCase
 
     public function testGet()
     {
-        $bag = new ImmutableBag([
+        $bag = $this->createBag([
             'foo'  => 'bar',
             'null' => null,
         ]);
@@ -161,7 +174,7 @@ class ImmutableBagTest extends TestCase
 
     public function testGetPath()
     {
-        $bag = new ImmutableBag([
+        $bag = $this->createBag([
             'items' => new ArrayObject([
                 'foo' => 'bar',
             ]),
@@ -175,68 +188,68 @@ class ImmutableBagTest extends TestCase
 
     public function testCount()
     {
-        $bag = new ImmutableBag(['foo', 'bar']);
+        $bag = $this->createBag(['foo', 'bar']);
 
         $this->assertEquals(2, count($bag));
     }
 
     public function testEmpty()
     {
-        $bag = new ImmutableBag(['foo', 'bar']);
+        $bag = $this->createBag(['foo', 'bar']);
         $this->assertFalse($bag->isEmpty());
 
-        $empty = new ImmutableBag();
+        $empty = $this->createBag();
         $this->assertTrue($empty->isEmpty());
     }
 
     public function testFirst()
     {
-        $bag = new ImmutableBag(['first', 'second']);
+        $bag = $this->createBag(['first', 'second']);
         $this->assertEquals('first', $bag->first());
 
-        $empty = new ImmutableBag();
+        $empty = $this->createBag();
         $this->assertFalse($empty->first());
     }
 
     public function testLast()
     {
-        $bag = new ImmutableBag(['first', 'second']);
+        $bag = $this->createBag(['first', 'second']);
         $this->assertEquals('second', $bag->last());
 
-        $empty = new ImmutableBag();
+        $empty = $this->createBag();
         $this->assertFalse($empty->last());
     }
 
     public function testJoin()
     {
-        $bag = new ImmutableBag(['first', 'second', 'third']);
+        $bag = $this->createBag(['first', 'second', 'third']);
         $this->assertEquals('first, second, third', $bag->join(', '));
 
-        $empty = new ImmutableBag();
+        $empty = $this->createBag();
         $this->assertEquals('', $empty->join(', '));
     }
 
     public function testSum()
     {
-        $bag = new ImmutableBag([3, 4]);
+        $bag = $this->createBag([3, 4]);
         $this->assertEquals(7, $bag->sum());
 
-        $empty = new ImmutableBag();
+        $empty = $this->createBag();
         $this->assertEquals(0, $empty->sum());
 
-        $dumb = new ImmutableBag(['wut']);
+        $dumb = $this->createBag(['wut']);
         $this->assertEquals(0, $dumb->sum());
     }
 
     public function testProduct()
     {
-        $bag = new ImmutableBag([3, 4]);
+        $bag = $this->createBag([3, 4]);
         $this->assertEquals(12, $bag->product());
 
-        $empty = new ImmutableBag();
+        $empty = $this->createBag();
         $this->assertEquals(1, $empty->product());
 
-        $dumb = new ImmutableBag(['wut']);
+        $dumb = $this->createBag(['wut']);
         $this->assertEquals(0, $dumb->product());
     }
 
@@ -248,7 +261,7 @@ class ImmutableBagTest extends TestCase
      */
     public function testIsAssociativeAndIndexed($data, $isIndexed)
     {
-        $bag = new ImmutableBag($data);
+        $bag = $this->createBag($data);
 
         $this->assertEquals($isIndexed, $bag->isIndexed());
         $this->assertEquals(!$isIndexed, $bag->isAssociative());
@@ -260,7 +273,7 @@ class ImmutableBagTest extends TestCase
 
     public function testMutable()
     {
-        $bag = new ImmutableBag(['foo' => 'bar']);
+        $bag = $this->createBag(['foo' => 'bar']);
 
         $mutable = $bag->mutable();
 
@@ -271,7 +284,7 @@ class ImmutableBagTest extends TestCase
 
     public function testImmutable()
     {
-        $bag = new Bag(['foo', 'bar']);
+        $bag = $this->createBag(['foo', 'bar']);
 
         $immutable = $bag->immutable();
 
@@ -282,7 +295,7 @@ class ImmutableBagTest extends TestCase
 
     public function testKeys()
     {
-        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world']);
+        $bag = $this->createBag(['foo' => 'bar', 'hello' => 'world']);
 
         $keys = $bag->keys();
 
@@ -291,7 +304,7 @@ class ImmutableBagTest extends TestCase
 
     public function testValues()
     {
-        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world']);
+        $bag = $this->createBag(['foo' => 'bar', 'hello' => 'world']);
 
         $values = $bag->values();
 
@@ -300,7 +313,7 @@ class ImmutableBagTest extends TestCase
 
     public function testMap()
     {
-        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world']);
+        $bag = $this->createBag(['foo' => 'bar', 'hello' => 'world']);
 
         $actual = $bag->map(function ($key, $item) {
             return $key . '.' . $item;
@@ -311,7 +324,7 @@ class ImmutableBagTest extends TestCase
 
     public function testMapKeys()
     {
-        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world']);
+        $bag = $this->createBag(['foo' => 'bar', 'hello' => 'world']);
 
         $actual = $bag->mapKeys(function ($key, $item) {
             return $key . '.' . $item;
@@ -322,7 +335,7 @@ class ImmutableBagTest extends TestCase
 
     public function testFilter()
     {
-        $bag = new ImmutableBag(['foo', 'bar', 'hello', 'world']);
+        $bag = $this->createBag(['foo', 'bar', 'hello', 'world']);
 
         $actual = $bag->filter(function ($key, $item) {
             return $item !== 'bar' && $key !== 2;
@@ -333,7 +346,7 @@ class ImmutableBagTest extends TestCase
 
     public function testClean()
     {
-        $bag = new ImmutableBag([null, '', 'foo', false, 0, true, [], ['bar']]);
+        $bag = $this->createBag([null, '', 'foo', false, 0, true, [], ['bar']]);
 
         $actual = $bag->clean();
 
@@ -342,7 +355,7 @@ class ImmutableBagTest extends TestCase
 
     public function testReplace()
     {
-        $bag = new ImmutableBag(['foo' => 'bar']);
+        $bag = $this->createBag(['foo' => 'bar']);
 
         $actual = $bag->replace(['foo' => 'baz', 'hello' => 'world']);
 
@@ -358,7 +371,8 @@ class ImmutableBagTest extends TestCase
      */
     public function testReplaceRecursive($array1, $array2, $expected)
     {
-        $bag = ImmutableBag::from($array1);
+        $cls = $this->cls;
+        $bag = $cls::from($array1);
 
         $actual = $bag->replaceRecursive($array2);
 
@@ -367,7 +381,7 @@ class ImmutableBagTest extends TestCase
 
     public function testDefaults()
     {
-        $bag = new ImmutableBag(['foo' => 'bar']);
+        $bag = $this->createBag(['foo' => 'bar']);
 
         $actual = $bag->defaults(['foo' => 'baz', 'hello' => 'world']);
 
@@ -383,7 +397,8 @@ class ImmutableBagTest extends TestCase
      */
     public function testDefaultsRecursive($array1, $array2, $expected)
     {
-        $bag = ImmutableBag::from($array2);
+        $cls = $this->cls;
+        $bag = $cls::from($array2);
 
         $actual = $bag->defaultsRecursive($array1);
 
@@ -392,7 +407,7 @@ class ImmutableBagTest extends TestCase
 
     public function testMerge()
     {
-        $bag = new ImmutableBag(['foo', 'bar']);
+        $bag = $this->createBag(['foo', 'bar']);
 
         $actual = $bag->merge(['hello', 'world']);
 
@@ -422,7 +437,7 @@ class ImmutableBagTest extends TestCase
      */
     public function testSlice($offset, $length, $preserveKeys, $expected)
     {
-        $bag = new ImmutableBag(['foo', 'bar', 'hello', 'world']);
+        $bag = $this->createBag(['foo', 'bar', 'hello', 'world']);
 
         $actual = $bag->slice($offset, $length, $preserveKeys);
 
@@ -431,7 +446,7 @@ class ImmutableBagTest extends TestCase
 
     public function testPartition()
     {
-        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world']);
+        $bag = $this->createBag(['foo' => 'bar', 'hello' => 'world']);
 
         $actual = $bag->partition(function ($key, $item) {
             return strpos($item, 'a') !== false;
@@ -447,7 +462,7 @@ class ImmutableBagTest extends TestCase
 
     public function testColumn()
     {
-        $bag = new ImmutableBag([
+        $bag = $this->createBag([
             ['id' => 'foo', 'value' => 'bar'],
             ['id' => 'hello', 'value' => 'world'],
         ]);
@@ -461,7 +476,7 @@ class ImmutableBagTest extends TestCase
 
     public function testFlip()
     {
-        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world', 'second' => 'world']);
+        $bag = $this->createBag(['foo' => 'bar', 'hello' => 'world', 'second' => 'world']);
 
         $actual = $bag->flip();
 
@@ -470,7 +485,7 @@ class ImmutableBagTest extends TestCase
 
     public function testReduce()
     {
-        $bag = new ImmutableBag([1, 2, 3, 4]);
+        $bag = $this->createBag([1, 2, 3, 4]);
 
         $product = $bag->reduce(
             function ($carry, $item) {
@@ -484,24 +499,24 @@ class ImmutableBagTest extends TestCase
 
     public function testUnique()
     {
-        $bag = new ImmutableBag(['foo', 'bar', 'foo', 3, '3', '3a', '3']);
+        $bag = $this->createBag(['foo', 'bar', 'foo', 3, '3', '3a', '3']);
         $actual = $bag->unique();
         $this->assertBagResult(['foo', 'bar', 3, '3', '3a'], $bag, $actual);
 
-        $first = new ImmutableBag();
-        $second = new ImmutableBag();
-        $bag = new ImmutableBag([$first, $second, $first]);
+        $first = $this->createBag();
+        $second = $this->createBag();
+        $bag = $this->createBag([$first, $second, $first]);
         $actual = $bag->unique();
         $this->assertBagResult([$first, $second], $bag, $actual);
     }
 
     public function testChunk()
     {
-        $bag = new ImmutableBag(['a', 'b', 'c', 'd', 'e']);
+        $bag = $this->createBag(['a', 'b', 'c', 'd', 'e']);
 
         $chunked = $bag->chunk(2);
 
-        $this->assertInstanceOf(ImmutableBag::class, $chunked);
+        $this->assertInstanceOf($this->cls, $chunked);
         $this->assertNotSame($bag, $chunked);
         $this->assertCount(3, $chunked);
 
@@ -512,11 +527,11 @@ class ImmutableBagTest extends TestCase
 
     public function testChunkPreserveKeys()
     {
-        $bag = new ImmutableBag(['a', 'b', 'c', 'd', 'e']);
+        $bag = $this->createBag(['a', 'b', 'c', 'd', 'e']);
 
         $chunked = $bag->chunk(2, true);
 
-        $this->assertInstanceOf(ImmutableBag::class, $chunked);
+        $this->assertInstanceOf($this->cls, $chunked);
         $this->assertNotSame($bag, $chunked);
         $this->assertCount(3, $chunked);
 
@@ -531,7 +546,7 @@ class ImmutableBagTest extends TestCase
 
     public function testReverse()
     {
-        $bag = new ImmutableBag(['a', 'b', 'c', 'd']);
+        $bag = $this->createBag(['a', 'b', 'c', 'd']);
 
         $actual = $bag->reverse();
 
@@ -540,7 +555,7 @@ class ImmutableBagTest extends TestCase
 
     public function testReversePreserveKeys()
     {
-        $bag = new ImmutableBag(['a', 'b', 'c', 'd']);
+        $bag = $this->createBag(['a', 'b', 'c', 'd']);
 
         $actual = $bag->reverse(true);
 
@@ -549,11 +564,11 @@ class ImmutableBagTest extends TestCase
 
     public function testShuffle()
     {
-        $bag = new ImmutableBag(['a', 'b', 'c', 'd']);
+        $bag = $this->createBag(['a', 'b', 'c', 'd']);
 
         $actual = $bag->shuffle();
 
-        $this->assertInstanceOf(ImmutableBag::class, $actual);
+        $this->assertInstanceOf($this->cls, $actual);
         $this->assertNotSame($bag, $actual);
 
         $sorted = $actual->toArray();
@@ -577,14 +592,14 @@ class ImmutableBagTest extends TestCase
 
     public function testIterator()
     {
-        $bag = new ImmutableBag(['a', 'b', 'c', 'd']);
+        $bag = $this->createBag(['a', 'b', 'c', 'd']);
 
         $this->assertEquals(['a', 'b', 'c', 'd'], iterator_to_array($bag));
     }
 
     public function testJsonSerializable()
     {
-        $bag = new ImmutableBag(['a', 'b', 'c']);
+        $bag = $this->createBag(['a', 'b', 'c']);
 
         $this->assertEquals('["a","b","c"]', json_encode($bag));
     }
@@ -592,7 +607,7 @@ class ImmutableBagTest extends TestCase
     public function testOffsetExists()
     {
         $arr = ['foo' => 'bar', 'null' => null];
-        $bag = new ImmutableBag($arr);
+        $bag = $this->createBag($arr);
 
         $this->assertTrue(isset($bag['foo']));
         $this->assertTrue(isset($bag['null'])); // doesn't have PHPs stupid edge case.
@@ -603,7 +618,7 @@ class ImmutableBagTest extends TestCase
 
     public function testOffsetGet()
     {
-        $bag = new ImmutableBag(['foo' => 'bar']);
+        $bag = $this->createBag(['foo' => 'bar']);
 
         $this->assertEquals('bar', $bag['foo']);
         $this->assertNull($bag['nope']);
@@ -616,7 +631,7 @@ class ImmutableBagTest extends TestCase
             // we also don't know if it's being asked for by reference to throw an exception.
         }
 
-        $bag = new ImmutableBag(['arr' => ['1']]);
+        $bag = $this->createBag(['arr' => ['1']]);
 
         // Assert arrays are not able to be modified by reference.
         $errors = new \ArrayObject();
@@ -637,7 +652,7 @@ class ImmutableBagTest extends TestCase
      */
     public function testOffsetSet()
     {
-        $bag = new ImmutableBag();
+        $bag = $this->createBag();
 
         $bag['foo'] = 'bar';
     }
@@ -648,14 +663,14 @@ class ImmutableBagTest extends TestCase
      */
     public function testOffsetUnset()
     {
-        $bag = new ImmutableBag(['foo' => 'bar']);
+        $bag = $this->createBag(['foo' => 'bar']);
 
         unset($bag['foo']);
     }
 
     public function testDebugInfo()
     {
-        $bag = new ImmutableBag(['foo' => 'bar']);
+        $bag = $this->createBag(['foo' => 'bar']);
 
         $this->assertEquals($bag->toArray(), $bag->__debugInfo());
         $this->assertEquals('bar', $bag->foo);
@@ -672,7 +687,7 @@ class ImmutableBagTest extends TestCase
      */
     protected function assertBagResult($expected, $initialBag, $actualBag)
     {
-        $this->assertInstanceOf(ImmutableBag::class, $actualBag);
+        $this->assertInstanceOf($this->cls, $actualBag);
         $this->assertNotSame($initialBag, $actualBag);
         $this->assertEquals($expected, $actualBag->toArray());
     }

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -555,11 +555,20 @@ class ImmutableBagTest extends TestCase
 
         $this->assertInstanceOf(ImmutableBag::class, $actual);
         $this->assertNotSame($bag, $actual);
-        $this->assertNotEquals($bag->toArray(), $actual->toArray());
 
         $sorted = $actual->toArray();
         sort($sorted);
         $this->assertEquals($bag->toArray(), $sorted);
+
+        // reduce odds that shuffle is produces same order.
+        for ($i = 0; $i < 10; ++$i) {
+            if ($bag->toArray() !== $actual->toArray()) {
+                break;
+            }
+            $actual = $bag->shuffle();
+        }
+
+        $this->assertNotEquals($bag->toArray(), $actual->toArray());
     }
 
     // endregion

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -5,8 +5,12 @@ namespace Bolt\Collection\Tests;
 use ArrayObject;
 use Bolt\Collection\Bag;
 use Bolt\Collection\ImmutableBag;
+use Bolt\Collection\MutableBag;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group legacy
+ */
 class ImmutableBagTest extends TestCase
 {
     /** @var string|ImmutableBag class used for static creation methods and instance of assertions */
@@ -278,7 +282,7 @@ class ImmutableBagTest extends TestCase
         $mutable = $bag->mutable();
 
         $this->assertNotSame($bag, $mutable);
-        $this->assertInstanceOf(Bag::class, $mutable);
+        $this->assertInstanceOf(MutableBag::class, $mutable);
         $this->assertEquals(['foo' => 'bar'], $mutable->toArray());
     }
 
@@ -289,7 +293,7 @@ class ImmutableBagTest extends TestCase
         $immutable = $bag->immutable();
 
         $this->assertNotSame($bag, $immutable);
-        $this->assertInstanceOf(ImmutableBag::class, $immutable);
+        $this->assertInstanceOf(Bag::class, $immutable);
         $this->assertEquals(['foo', 'bar'], $immutable->toArray());
     }
 

--- a/tests/MutableBagTest.php
+++ b/tests/MutableBagTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bolt\Collection\Tests;
+
+use Bolt\Collection\MutableBag;
+
+class MutableBagTest extends BagTest
+{
+    /** @var string|MutableBag */
+    protected $cls = MutableBag::class;
+
+    protected function createBag($items = [])
+    {
+        return new MutableBag($items);
+    }
+}


### PR DESCRIPTION
After working with these classes more, I realize that the naming is probably backwards. Immutable _should_ be the default.

So this deprecates the `ImmutableBag` class.
`Bag` will be the new immutable...bag. All of its mutable methods are deprecated.
`MutableBag` is the new class for mutation.

Here's an example.
Previously:
```php
public function colors(): ImmutableBag
{
    $bag = new Bag();
    $bag->add('red');
    $bag->add('blue');

    return $bag;
}
```

Now with this PR:
```php
public function colors(): Bag
{
    $bag = new MutableBag();
    $bag->add('red');
    $bag->add('blue');

    return $bag;
}
```
This way feels more natural; almost like a builder class that returns a read-only view. 

Most of the time we don't even need mutability because we just create the bag with the items. Also most "modification" methods return a new bag anyways.
```php
public function colors(): Bag
{
    $bag = Bag::from(['red', 'blue']);
    $bag = $bag->reverse();

    return $bag;
}
```