### PR TITLE
Added Arr::from() and fromRecursive()

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -17,6 +17,56 @@ use Traversable;
 class Arr
 {
     /**
+     * Converts an iterable, null, or stdClass to an array.
+     *
+     * @param iterable|null|\stdClass $iterable
+     *
+     * @return array
+     */
+    public static function from($iterable)
+    {
+        if (is_array($iterable)) {
+            return $iterable;
+        }
+        // Don't mean to play favorites, but want to optimize where we can.
+        if ($iterable instanceof ImmutableBag) {
+            return $iterable->toArray();
+        }
+        if ($iterable instanceof Traversable) {
+            return iterator_to_array($iterable);
+        }
+        if ($iterable === null) {
+            return [];
+        }
+        if ($iterable instanceof \stdClass) {
+            return (array) $iterable;
+        }
+
+        Assert::nullOrIsIterable($iterable);
+    }
+
+    /**
+     * Recursively converts an iterable to nested arrays.
+     *
+     * @param iterable|null|\stdClass $iterable
+     *
+     * @return array
+     */
+    public static function fromRecursive($iterable)
+    {
+        $arr = static::from($iterable);
+
+        foreach ($arr as $key => $value) {
+            if ($value instanceof \stdClass || is_iterable($value)) {
+                $value = static::fromRecursive($value);
+            }
+            $arr[$key] = $value;
+        }
+
+        return $arr;
+    }
+
+    /**
      * Return the values from a single column in the input array, identified by the $columnKey.
      *
      * Optionally, an $indexKey may be provided to index the values in the returned array by the

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -16,6 +16,68 @@ use PHPUnit\Framework\TestCase;
  */
 class ArrTest extends TestCase
 {
+    public function provideFrom()
+    {
+        return [
+            'array' => [
+                ['foo' => 'bar'],
+                ['foo' => 'bar'],
+            ],
+            'bag' => [
+                new Bag(['foo' => 'bar']),
+                ['foo' => 'bar'],
+            ],
+            'traversable' => [
+                new \ArrayIterator(['foo' => 'bar']),
+                ['foo' => 'bar'],
+            ],
+            'null' => [
+                null,
+                [],
+            ],
+            'stdClass' => [
+                (object) ['foo' => 'bar'],
+                ['foo' => 'bar'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFrom
+     *
+     * @param $input
+     * @param $expected
+     */
+    public function testFrom($input, $expected)
+    {
+        $this->assertSame($expected, Arr::from($input));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Expected an iterable. Got: Exception
+     */
+    public function testFromNonIterable()
+    {
+        Arr::from(new \Exception());
+    }
+
+    public function testFromRecursive()
+    {
+        $expected = [
+            'foo'    => 'bar',
+            'colors' => ['red', 'blue'],
+            'items'  => ['hello', 'world'],
+        ];
+        $input = new Bag([
+            'foo'    => 'bar',
+            'colors' => new Bag(['red', 'blue']),
+            'items'  => (object) ['hello', 'world'],
+        ]);
+
+        $this->assertSame($expected, Arr::fromRecursive($input));
+    }
+
     public function testColumn()
     {
         $data = new \ArrayIterator([

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -31,7 +31,6 @@ class ImmutableBagTest extends TestCase
             'null'        => [null, []],
             'stdClass'    => [json_decode(json_encode(['foo' => 'bar']))],
             'array'       => [['foo' => 'bar']],
-            'mixed'       => ['derp', ['derp']],
         ];
     }
 


### PR DESCRIPTION
`Arr::from()` normalizes iterables, null, and stdClass to arrays.
`Arr::fromRecursive()` does the same thing recursively (this was previously locked away in a private Bag method).

-----

[RFC] Bags, when normalizing collections, convert non-iterables to an array of one item. I didn't think that was appropriate for `Arr::from()`. And I'm wondering if that should be deprecated/immediately removed from Bags as well. It is a bit of an edge case and I don't think it even makes sense:
```php
$bag = new Bag(['blue']);
$bag->replace('red');
// bag is now ['red']
```