### PR TITLE
Added reject()

### DIFF
--- a/src/ImmutableBag.php
+++ b/src/ImmutableBag.php
@@ -428,6 +428,28 @@ class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSer
     }
 
     /**
+     * Returns a bag with the items that do not satisfy the predicate $callback, the opposite of {@see filter}.
+     *
+     * Keys are preserved, so lists could need to be re-indexed.
+     *
+     * @param callable $callback The predicate used for filtering. Function is passed (key, value).
+     *
+     * @return static
+     */
+    public function reject(callable $callback)
+    {
+        $items = [];
+
+        foreach ($this->items as $key => $value) {
+            if (!$callback($key, $value)) {
+                $items[$key] = $value;
+            }
+        }
+
+        return $this->createFrom($items);
+    }
+
+    /**
      * Returns a bag with falsely values filtered out.
      *
      * @return static

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -347,6 +347,17 @@ class ImmutableBagTest extends TestCase
         $this->assertBagResult([0 => 'foo', 3 => 'world'], $bag, $actual);
     }
 
+    public function testReject()
+    {
+        $bag = $this->createBag(['foo', 'bar', 'hello', 'world']);
+
+        $actual = $bag->reject(function ($key, $item) {
+            return $item !== 'bar' && $key !== 2;
+        });
+
+        $this->assertBagResult([1 => 'bar', 2 => 'hello'], $bag, $actual);
+    }
+
     public function testClean()
     {
         $bag = $this->createBag([null, '', 'foo', false, 0, true, [], ['bar']]);


### PR DESCRIPTION
Reject - Returns a bag with the items that do not satisfy the predicate.
Just the opposite of `filter()`.

```php
$bag = Bag::from(['red', 'blue', 'black']);

$bag->reject(function ($i, $color) {
    return $color[0] === 'b';
});
// => ['red']
```