### PR TITLE
Added Arr::mapRecursive

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -367,6 +367,43 @@ class Arr
     }
 
     /**
+     * Returns an array with the given $callable applied to each leaf value in the given $iterable.
+     *
+     * This converts all nested iterables to arrays.
+     *
+     * @param iterable $iterable
+     * @param callable $callable Function is passed ($value, $key)
+     *
+     * @return array
+     */
+    public static function mapRecursive($iterable, callable $callable)
+    {
+        Assert::isIterable($iterable);
+
+        return static::doMapRecursive($iterable, $callable);
+    }
+
+    /**
+     * Internal method do actual recursion after args have been validated by main method.
+     *
+     * @param iterable $iterable
+     * @param callable $callable
+     *
+     * @return array
+     */
+    private static function doMapRecursive($iterable, callable $callable)
+    {
+        $mapped = [];
+        foreach ($iterable as $key => $value) {
+            $mapped[$key] = is_iterable($value) ?
+                static::doMapRecursive($value, $callable) :
+                $callable($value, $key);
+        }
+
+        return $mapped;
+    }
+
+    /**
      * Replaces values from second array into first array recursively.
      *
      * This differs from {@see array_replace_recursive} in a couple ways:

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -380,6 +380,14 @@ class Arr
     {
         Assert::isIterable($iterable);
 
+        // If internal method with one arg, like strtolower, limit to first arg so warning isn't triggered.
+        $ref = new \ReflectionFunction($callable);
+        if ($ref->isInternal() && $ref->getNumberOfParameters() === 1) {
+            $callable = function ($arg) use ($callable) {
+                return $callable($arg);
+            };
+        }
+
         return static::doMapRecursive($iterable, $callable);
     }
 

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -402,6 +402,25 @@ class ArrTest extends TestCase
         $this->assertFalse(Arr::isAssociative('derp'));
     }
 
+    public function testMapRecursive()
+    {
+        $arr = [
+            'foo' => new \ArrayObject([
+                'bar' => 'HELLO',
+            ]),
+        ];
+
+        $actual = Arr::mapRecursive($arr, 'strtolower');
+
+        $expected = [
+            'foo' => [
+                'bar' => 'hello',
+            ],
+        ];
+
+        $this->assertSame($expected, $actual);
+    }
+
     public function provideReplaceRecursive()
     {
         return [


### PR DESCRIPTION
`mapRecursive` returns an array with the given $callable applied to each leaf value in the given $iterable. All nested iterables are converted to arrays.

```php
$arr = [
    'foo' => new \ArrayObject([
        'bar' => 'HELLO',
    ]),
];

Arr::mapRecursive($arr, function ($item, $key) {
    return strtolower($item);
});
// => [
//     'foo' => [
//         'bar' => 'hello',
//     ],
// ]
```
-----

There's also a bit of magic for builtin functions. Since we call the function with `($value, $key)` - builtin methods do not like the second argument so we filter that out. This allows the method to be called like this:
```php
Arr::mapRecursive($arr, 'strtolower');
```
But I'm not sure if this is a good thing to keep or not. Thoughts?