### PR TITLE
Added call() to allow for custom functionality

### DIFF
--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -274,6 +274,23 @@ class ImmutableBagTest extends TestCase
 
     // region Methods returning a new bag
 
+    public function testCall()
+    {
+        $bag = $this->createBag(['red', 'blue']);
+
+        $result = $bag->call(
+            function (array $colors, $arg1) {
+                $colors[] = 'green';
+                $colors[] = $arg1;
+
+                return $colors;
+            },
+            'black'
+        );
+
+        $this->assertBagResult(['red', 'blue', 'green', 'black'], $bag, $result);
+    }
+
     public function testMutable()
     {
         $bag = $this->createBag(['foo' => 'bar']);


### PR DESCRIPTION
At certain times you may need to do something that `Bag` doesn't have functionality for. Annoyingly you have to convert the bag to an array, do your thing, then create a new bag. This also breaks the chain-ability.
```php
$bag = Bag::from(['red', 'blue']);

// Assuming Bag does not have a flip() method ;)
$bag = Bag::from(array_flip($bag->toArray()));

$bag->keys();
// => Bag of ['red', 'blue']
```

Now with the new `call()` method:
```php
Bag::from(['red', 'blue'])
    ->call('array_flip')
    ->keys()
;
// => Bag of ['red', 'blue']
```

Here's another example with a closure:
```php
Bag::from(['red', 'blue'])
    ->call(function (array $colors) {
        $colors[] = 'green';

        return $colors;
    })
;
// => Bag of ['red', 'blue', 'green']
```

And another one using [array_change_key_case](http://php.net/manual/en/function.array-change-key-case.php) with a parameter:
```php
Bag::from(['red', 'blue'])
    ->flip()
    ->call('array_change_key_case', CASE_UPPER)
;
// => Bag of ['RED' => 0, 'BLUE' => 1]

```
