### PR TITLE
Change first & last to return null instead of false if the bag is empty

### DIFF
--- a/src/ImmutableBag.php
+++ b/src/ImmutableBag.php
@@ -242,23 +242,23 @@ class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSer
     }
 
     /**
-     * Returns the first item in the list.
+     * Returns the first item in the list or null if empty.
      *
-     * @return mixed
+     * @return mixed|null
      */
     public function first()
     {
-        return reset($this->items);
+        return $this->items ? reset($this->items) : null;
     }
 
     /**
-     * Returns the last item in the list.
+     * Returns the last item in the list or null if empty.
      *
-     * @return mixed
+     * @return mixed|null
      */
     public function last()
     {
-        return end($this->items);
+        return $this->items ? end($this->items) : null;
     }
 
     /**

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -211,7 +211,7 @@ class ImmutableBagTest extends TestCase
         $this->assertEquals('first', $bag->first());
 
         $empty = $this->createBag();
-        $this->assertFalse($empty->first());
+        $this->assertNull($empty->first());
     }
 
     public function testLast()
@@ -220,7 +220,7 @@ class ImmutableBagTest extends TestCase
         $this->assertEquals('second', $bag->last());
 
         $empty = $this->createBag();
-        $this->assertFalse($empty->last());
+        $this->assertNull($empty->last());
     }
 
     public function testJoin()


### PR DESCRIPTION
In order to be consistent with the rest of the methods, failures should throw exceptions or return null. This could be considered a minor BC break, but I think it will be ok.