### PR TITLE
Move countValues() to ImmutableBag to be consistent for 1.x

### DIFF
--- a/src/Bag.php
+++ b/src/Bag.php
@@ -28,20 +28,6 @@ class Bag extends ImmutableBag
 
     // endregion
 
-    // region Methods returning a new bag
-
-    /**
-     * Returns a bag with values mapped to the number of times they are in the bag.
-     *
-     * @return static [value => count]
-     */
-    public function countValues()
-    {
-        return $this->createFrom(array_count_values($this->items));
-    }
-
-    // endregion
-
     // region Mutating Methods (Deprecated)
 
     /**

--- a/src/ImmutableBag.php
+++ b/src/ImmutableBag.php
@@ -888,6 +888,16 @@ class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSer
         return $this->createFrom(array_pad($this->items, $size, $value));
     }
 
+    /**
+     * Returns a bag with values mapped to the number of times they are in the bag.
+     *
+     * @return static [value => count]
+     */
+    public function countValues()
+    {
+        return $this->createFrom(array_count_values($this->items));
+    }
+
     // endregion
 
     // region Comparison Methods

--- a/tests/BagTest.php
+++ b/tests/BagTest.php
@@ -15,22 +15,6 @@ class BagTest extends ImmutableBagTest
         return new Bag($items);
     }
 
-    // region Methods returning a new bag
-
-    public function testCountValues()
-    {
-        $bag = $this->createBag([
-            'red',
-            'red',
-            'blue',
-        ]);
-
-        $actual = $bag->countValues();
-        $this->assertBagResult(['red' => 2, 'blue' => 1], $bag, $actual);
-    }
-
-    // endregion
-
     // region Mutating Methods (Deprecated)
 
     /**

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -754,6 +754,18 @@ class ImmutableBagTest extends TestCase
         $this->assertBagResult([1, 2], $bag, $padded);
     }
 
+    public function testCountValues()
+    {
+        $bag = $this->createBag([
+            'red',
+            'red',
+            'blue',
+        ]);
+
+        $actual = $bag->countValues();
+        $this->assertBagResult(['red' => 2, 'blue' => 1], $bag, $actual);
+    }
+
     // endregion
 
     // region Comparison Methods


### PR DESCRIPTION
All the `ImmutableBag` methods will be moved to `Bag` in 2.0.
