### PR TITLE
Added flatten()

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -522,6 +522,52 @@ class Arr
     }
 
     /**
+     * Flattens an iterable.
+     *
+     * Example:
+     *     Arr::flatten([1, [2, 3], [4]])
+     *     // => [1, 2, 3, 4]
+     *
+     * @param iterable $iterable The iterable to flatten
+     * @param int      $depth    How deep to flatten
+     *
+     * @return array
+     */
+    public static function flatten($iterable, $depth = 1)
+    {
+        Assert::isIterable($iterable);
+
+        return static::doFlatten(
+            $iterable,
+            $depth,
+            'is_iterable' // This may be more configurable in the future.
+        );
+    }
+
+    /**
+     * Internal method to do actual flatten recursion after args have been validated by main method.
+     *
+     * @param iterable $iterable  The iterable to flatten
+     * @param int      $depth     How deep to flatten
+     * @param callable $predicate Whether to recurse the item
+     * @param array    $result    The result array
+     *
+     * @return array
+     */
+    private static function doFlatten($iterable, $depth, callable $predicate, array $result = [])
+    {
+        foreach ($iterable as $item) {
+            if ($depth >= 1 && $predicate($item)) {
+                $result = static::doFlatten($item, $depth - 1, $predicate, $result);
+            } else {
+                $result[] = $item;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Private Constructor.
      *
      * @codeCoverageIgnore

--- a/src/ImmutableBag.php
+++ b/src/ImmutableBag.php
@@ -888,6 +888,22 @@ class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSer
         return $this->createFrom(array_pad($this->items, $size, $value));
     }
 
+    /**
+     * Returns a bag with the items flattened.
+     *
+     * Example:
+     *     Bag::from([1, [2, 3], [4]])->flatten()
+     *     // => Bag of [1, 2, 3, 4]
+     *
+     * @param int $depth How deep to flatten
+     *
+     * @return static
+     */
+    public function flatten($depth = 1)
+    {
+        return $this->createFrom(Arr::flatten($this->items, $depth));
+    }
+
     // endregion
 
     // region Comparison Methods

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -495,4 +495,18 @@ class ArrTest extends TestCase
     {
         $this->assertEquals($result, Arr::replaceRecursive($array1, $array2));
     }
+
+    public function testFlatten()
+    {
+        $result = Arr::flatten([[1, 2], [[3]], 4]);
+
+        $this->assertSame([1, 2, [3], 4], $result);
+    }
+
+    public function testFlattenDeep()
+    {
+        $result = Arr::flatten([[1, 2], [[3]], 4], INF);
+
+        $this->assertSame([1, 2, 3, 4], $result);
+    }
 }

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -754,6 +754,15 @@ class ImmutableBagTest extends TestCase
         $this->assertBagResult([1, 2], $bag, $padded);
     }
 
+    public function testFlatten()
+    {
+        $bag = $this->createBag([[1, 2], [[3]], 4]);
+
+        $result = $bag->flatten();
+
+        $this->assertBagResult([1, 2, [3], 4], $bag, $result);
+    }
+
     // endregion
 
     // region Comparison Methods


### PR DESCRIPTION
Added flatten with variable depth to `Arr` and `Bag`.
```php
$arr = [1, [2, [3]], [4]];

Arr::flatten($arr);
// => [1, 2, [3], 4]

Arr::flatten($arr, INF);
// => [1, 2, 3, 4]
```
```php
$bag = Bag::from([1, [2, [3]], [4]]);

$bag->flatten();
// => Bag of [1, 2, [3], 4]

$bag->flatten(INF);
// => Bag of [1, 2, 3, 4]
```
