### PR TITLE
Added sorting methods

### DIFF
--- a/src/ImmutableBag.php
+++ b/src/ImmutableBag.php
@@ -1119,6 +1119,139 @@ class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSer
     // region Sorting Methods
 
     /**
+     * Returns a bag with the values sorted.
+     *
+     * Sorting flags:
+     * <pre>
+     *  - SORT_REGULAR                  - compare values without changing types
+     *  - SORT_NUMERIC                  - compare values numerically
+     *  - SORT_STRING                   - compare values as strings
+     *  - SORT_STRING | SORT_FLAG_CASE  - compare values as strings ignoring case
+     *  - SORT_LOCALE_STRING            - compare values as strings based on the current locale
+     *  - SORT_NATURAL                  - compare values as strings using "natural ordering"
+     *  - SORT_NATURAL | SORT_FLAG_CASE - compare values as strings using "natural ordering" ignoring case
+     * </pre>
+     *
+     * @param int  $order        SORT_ASC or SORT_DESC
+     * @param int  $flags        Sorting flags to modify the behavior
+     * @param bool $preserveKeys Whether to preserve keys for maps or to re-index for lists
+     *
+     * @return static
+     */
+    public function sort($order = SORT_ASC, $flags = SORT_REGULAR, $preserveKeys = false)
+    {
+        $this->validateSortArgs($order, $flags);
+
+        $items = $this->items;
+
+        if (!$preserveKeys) {
+            if ($order === SORT_ASC) {
+                sort($items, $flags);
+            } elseif ($order === SORT_DESC) {
+                rsort($items, $flags);
+            }
+        } else {
+            if ($order === SORT_ASC) {
+                asort($items, $flags);
+            } elseif ($order === SORT_DESC) {
+                arsort($items, $flags);
+            }
+        }
+
+        return $this->createFrom($items);
+    }
+
+    /**
+     * Returns a bag with the values sorted with the given $comparator.
+     *
+     * @param callable $comparator   Comparator function given ($itemA, $itemB)
+     * @param bool     $preserveKeys Whether to preserve keys for maps or to re-index for lists
+     *
+     * @return static
+     */
+    public function sortWith(callable $comparator, $preserveKeys = false)
+    {
+        $items = $this->items;
+
+        $preserveKeys ? uasort($items, $comparator) : usort($items, $comparator);
+
+        return $this->createFrom($items);
+    }
+
+    /**
+     * Returns a bag with the keys sorted.
+     *
+     * Sorting flags:
+     * <pre>
+     *  - SORT_REGULAR                  - compare keys without changing types
+     *  - SORT_NUMERIC                  - compare keys numerically
+     *  - SORT_STRING                   - compare keys as strings
+     *  - SORT_STRING | SORT_FLAG_CASE  - compare keys as strings ignoring case
+     *  - SORT_LOCALE_STRING            - compare keys as strings based on the current locale
+     *  - SORT_NATURAL                  - compare keys as strings using "natural ordering"
+     *  - SORT_NATURAL | SORT_FLAG_CASE - compare keys as strings using "natural ordering" ignoring case
+     * </pre>
+     *
+     * @param int $order SORT_ASC or SORT_DESC
+     * @param int $flags Sorting flags to modify the behavior
+     *
+     * @return static
+     */
+    public function sortKeys($order = SORT_ASC, $flags = SORT_REGULAR)
+    {
+        $this->validateSortArgs($order, $flags);
+
+        $items = $this->items;
+
+        if ($order === SORT_ASC) {
+            ksort($items, $flags);
+        } else {
+            krsort($items, $flags);
+        }
+
+        return $this->createFrom($items);
+    }
+
+    /**
+     * Returns a bag with the keys sorted with the given $comparator.
+     *
+     * @param callable $comparator Comparator function given ($keyA, $keyB)
+     *
+     * @return static
+     */
+    public function sortKeysWith(callable $comparator)
+    {
+        $items = $this->items;
+
+        uksort($items, $comparator);
+
+        return $this->createFrom($items);
+    }
+
+    /**
+     * @param int $order
+     * @param int $flags
+     */
+    private function validateSortArgs($order, $flags)
+    {
+        Assert::oneOf($order, [SORT_ASC, SORT_DESC], 'Expected $order to be SORT_ASC or SORT_DESC. Got: %s');
+
+        Assert::oneOf(
+            $flags,
+            [
+                SORT_REGULAR,
+                SORT_NUMERIC,
+                SORT_STRING,
+                SORT_LOCALE_STRING,
+                SORT_NATURAL,
+                SORT_STRING | SORT_FLAG_CASE,
+                SORT_NATURAL | SORT_FLAG_CASE,
+            ],
+            'Expected $flags to be one of: SORT_REGULAR, SORT_NUMERIC, SORT_STRING [ | SORT_FLAG_CASE], SORT_LOCALE_STRING, or SORT_NATURAL [ | SORT_FLAG_CASE]. Got: %s'
+        );
+    }
+
+    /**
      * Returns a bag with the items reversed.
      *
      * @param bool $preserveKeys If true numeric keys are preserved. Non-numeric keys are always preserved.

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -945,6 +945,143 @@ class ImmutableBagTest extends TestCase
 
     // region Sorting Methods
 
+    public function testSortValuesAsc()
+    {
+        $bag = $this->createBag([4, 'hi' => 3, 1, 2]);
+
+        $sorted = $bag->sort();
+
+        $this->assertBagResult([1, 2, 3, 4], $bag, $sorted);
+    }
+
+    public function testSortValuesAscNaturalIgnoreCase()
+    {
+        $bag = $this->createBag(
+            [
+                'img12.png',
+                'img1.png',
+                'iMg2.png',
+                'img10.png',
+            ]
+        );
+
+        $sorted = $bag->sort(SORT_ASC, SORT_NATURAL | SORT_FLAG_CASE);
+
+        $expected = [
+            'img1.png',
+            'iMg2.png',
+            'img10.png',
+            'img12.png',
+        ];
+        $this->assertBagResult($expected, $bag, $sorted);
+    }
+
+    public function testSortValuesAscPreserveKeys()
+    {
+        $bag = $this->createBag(['a' => 4, 'b' => 3, 'c' => 1, 'd' => 2]);
+
+        $sorted = $bag->sort(SORT_ASC, SORT_REGULAR, true);
+
+        $this->assertBagResult(['c' => 1, 'd' => 2, 'b' => 3, 'a' => 4], $bag, $sorted);
+    }
+
+    public function testSortValuesDesc()
+    {
+        $bag = $this->createBag([4, 'hi' => 3, 1, 2]);
+
+        $sorted = $bag->sort(SORT_DESC);
+
+        $this->assertBagResult([4, 3, 2, 1], $bag, $sorted);
+    }
+
+    public function testSortValuesDescPreserveKeys()
+    {
+        $bag = $this->createBag(['a' => 4, 'b' => 3, 'c' => 1, 'd' => 2]);
+
+        $sorted = $bag->sort(SORT_DESC, SORT_REGULAR, true);
+
+        $this->assertBagResult(['a' => 4, 'b' => 3, 'd' => 2, 'c' => 1], $bag, $sorted);
+    }
+
+    public function testSortValuesWithComparator()
+    {
+        $bag = $this->createBag(['blue', 'red', 'black']);
+
+        $sorted = $bag->sortWith(
+            function ($a, $b) {
+                $a = $a[0];
+                $b = $b[0];
+
+                if ($a === $b) {
+                    return 0;
+                }
+
+                return $a > $b ? 1 : -1;
+            }
+        );
+
+        $this->assertBagResult(['blue', 'black', 'red'], $bag, $sorted);
+    }
+
+    public function testSortValuesWithComparatorPreserveKeys()
+    {
+        $bag = $this->createBag(['blue', 'red', 'black']);
+
+        $sorted = $bag->sortWith(
+            function ($a, $b) {
+                $a = $a[0];
+                $b = $b[0];
+
+                if ($a === $b) {
+                    return 0;
+                }
+
+                return $a > $b ? 1 : -1;
+            },
+            true
+        );
+
+        $this->assertBagResult([0 => 'blue', 2 => 'black', 1 => 'red'], $bag, $sorted);
+    }
+
+    public function testSortKeysAsc()
+    {
+        $bag = $this->createBag(['c' => 1, 'd' => 2, 'b' => 3, 'a' => 4]);
+
+        $sorted = $bag->sortKeys();
+
+        $this->assertBagResult(['a' => 4, 'b' => 3, 'c' => 1, 'd' => 2], $bag, $sorted);
+    }
+
+    public function testSortKeysDesc()
+    {
+        $bag = $this->createBag(['c' => 1, 'd' => 2, 'b' => 3, 'a' => 4]);
+
+        $sorted = $bag->sortKeys(SORT_DESC);
+
+        $this->assertBagResult(['d' => 2, 'c' => 1, 'b' => 3, 'a' => 4], $bag, $sorted);
+    }
+
+    public function testSortKeysWithComparator()
+    {
+        $bag = $this->createBag(['blue' => 'a', 'red' => 'b', 'black' => 'c']);
+
+        $sorted = $bag->sortKeysWith(
+            function ($a, $b) {
+                $a = $a[0];
+                $b = $b[0];
+
+                if ($a === $b) {
+                    return 0;
+                }
+
+                return $a > $b ? 1 : -1;
+            }
+        );
+
+        $this->assertBagResult(['blue' => 'a', 'black' => 'c', 'red' => 'b'], $bag, $sorted);
+    }
+
     public function testReverse()
     {
         $bag = $this->createBag(['a', 'b', 'c', 'd']);

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -1044,6 +1044,78 @@ class ImmutableBagTest extends TestCase
         $this->assertBagResult([0 => 'blue', 2 => 'black', 1 => 'red'], $bag, $sorted);
     }
 
+    public function testSortValuesByAsc()
+    {
+        $bag = $this->createBag(
+            [
+                ['name' => 'Bob'],
+                ['name' => 'Carson'],
+                ['name' => 'Alice'],
+            ]
+        );
+
+        $sorted = $bag->sortBy(
+            function ($item) {
+                return $item['name'];
+            }
+        );
+
+        $expected = [
+            ['name' => 'Alice'],
+            ['name' => 'Bob'],
+            ['name' => 'Carson'],
+        ];
+
+        $this->assertBagResult($expected, $bag, $sorted);
+    }
+
+    public function testSortValuesByDesc()
+    {
+        $bag = $this->createBag(
+            [
+                ['name' => 'Bob'],
+                ['name' => 'Carson'],
+                ['name' => 'Alice'],
+            ]
+        );
+
+        $sorted = $bag->sortBy(
+            function ($item) {
+                return $item['name'];
+            },
+            SORT_DESC
+        );
+
+        $expected = [
+            ['name' => 'Carson'],
+            ['name' => 'Bob'],
+            ['name' => 'Alice'],
+        ];
+
+        $this->assertBagResult($expected, $bag, $sorted);
+    }
+
+    public function testSortValuesByPreserveKeys()
+    {
+        $bag = $this->createBag(['blue', 'red', 'black']);
+
+        $sorted = $bag->sortWith(
+            function ($a, $b) {
+                $a = $a[0];
+                $b = $b[0];
+
+                if ($a === $b) {
+                    return 0;
+                }
+
+                return $a > $b ? 1 : -1;
+            },
+            true
+        );
+
+        $this->assertBagResult([0 => 'blue', 2 => 'black', 1 => 'red'], $bag, $sorted);
+    }
+
     public function testSortKeysAsc()
     {
         $bag = $this->createBag(['c' => 1, 'd' => 2, 'b' => 3, 'a' => 4]);
@@ -1080,6 +1152,33 @@ class ImmutableBagTest extends TestCase
         );
 
         $this->assertBagResult(['blue' => 'a', 'black' => 'c', 'red' => 'b'], $bag, $sorted);
+    }
+
+    public function testSortKeysByAsc()
+    {
+        $bag = $this->createBag(['blue' => 'a', 'red' => 'b', 'black' => 'c']);
+
+        $sorted = $bag->sortKeysBy(
+            function ($key) {
+                return $key[0];
+            }
+        );
+
+        $this->assertBagResult(['blue' => 'a', 'black' => 'c', 'red' => 'b'], $bag, $sorted);
+    }
+
+    public function testSortKeysByDesc()
+    {
+        $bag = $this->createBag(['blue' => 'a', 'red' => 'b', 'black' => 'c']);
+
+        $sorted = $bag->sortKeysBy(
+            function ($key) {
+                return $key[0];
+            },
+            SORT_DESC
+        );
+
+        $this->assertBagResult(['red' => 'b', 'blue' => 'a', 'black' => 'c'], $bag, $sorted);
     }
 
     public function testReverse()


### PR DESCRIPTION
Sort values:
```php
public function sort($order = SORT_ASC, $flags = SORT_REGULAR, $preserveKeys = false): Bag

public function sortBy(($item): mixed $iteratee, $order = SORT_ASC, $preserveKeys = false): Bag

public function sortWith(($a, $b): int $comparator, $preserveKeys = false): Bag
```
Sort keys:
```php
public function sortKeys($order = SORT_ASC, $flags = SORT_REGULAR): Bag

public function sortKeysBy(($key): mixed $iteratee, $order = SORT_ASC): Bag

public function sortKeysWith(($a, $b): int $comparator): Bag
```