### PR TITLE
Added remove at path methods

### DIFF
--- a/src/MutableBag.php
+++ b/src/MutableBag.php
@@ -104,6 +104,33 @@ class MutableBag extends Bag
     }
 
     /**
+     * Removes and returns a value at the path given.
+     *
+     * This function does not support keys that contain "/" or "[]" characters
+     * because these are special tokens used when traversing the data structure.
+     *
+     * Example:
+     *     removePath('foo/bar');
+     *     // => 'baz'
+     *     removePath('foo/bar');
+     *     // => null
+     *
+     * Note: To set values not directly under ArrayAccess objects their
+     * offsetGet() method needs to be defined as return by reference.
+     *
+     *     public function &offsetGet($offset) {}
+     *
+     * @param string     $path    Path to traverse and remove the value at
+     * @param mixed|null $default Default value to return if key does not exist
+     *
+     * @return mixed
+     */
+    public function removePath($path, $default = null)
+    {
+        return Arr::remove($this->items, $path, $default);
+    }
+
+    /**
      * Removes the given item from the bag if it is found.
      *
      * @param mixed $item

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -156,9 +156,11 @@ class ArrTest extends TestCase
             'array' => [
                 [
                     'foo'   => 'bar',
+                    'baz'   => 'remove',
                     'items' => [
                         'nested' => [
                             'hello' => 'world',
+                            'bye'   => 'earth',
                         ],
                         'obj' => new \EmptyIterator(),
                     ],
@@ -168,9 +170,11 @@ class ArrTest extends TestCase
             'array access' => [
                 new \ArrayObject([
                     'foo'   => 'bar',
+                    'baz'   => 'remove',
                     'items' => new \ArrayObject([
                         'nested' => new \ArrayObject([
                             'hello' => 'world',
+                            'bye'   => 'earth',
                         ]),
                         'obj' => new \EmptyIterator(),
                     ]),
@@ -180,9 +184,11 @@ class ArrTest extends TestCase
             'user array access' => [
                 new TestArrayLike([
                     'foo'   => 'bar',
+                    'baz'   => 'remove',
                     'items' => new TestArrayLike([
                         'nested' => new TestArrayLike([
                             'hello' => 'world',
+                            'bye'   => 'earth',
                         ]),
                         'obj' => new \EmptyIterator(),
                     ]),
@@ -192,9 +198,11 @@ class ArrTest extends TestCase
             'mixed' => [
                 [
                     'foo'   => 'bar',
+                    'baz'   => 'remove',
                     'items' => new \ArrayObject([
                         'nested' => [
                             'hello' => 'world',
+                            'bye'   => 'earth',
                         ],
                         'obj' => new \EmptyIterator(),
                     ]),
@@ -331,6 +339,20 @@ class ArrTest extends TestCase
         } else {
             $this->fail("Arr::set should've thrown a RuntimeException");
         }
+    }
+
+    /**
+     * @dataProvider provideGetSetHas
+     *
+     * @param array|\ArrayAccess $data
+     */
+    public function testRemove($data)
+    {
+        $this->assertSame('remove', Arr::remove($data, 'baz', 'default'));
+        $this->assertSame('default', Arr::remove($data, 'baz', 'default'));
+
+        $this->assertSame('earth', Arr::remove($data, 'items/nested/bye', 'default'));
+        $this->assertSame('default', Arr::remove($data, 'items/nested/bye', 'default'));
     }
 
     public function testIsAccessible()

--- a/tests/MutableBagTest.php
+++ b/tests/MutableBagTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Collection\Tests;
 
+use ArrayObject;
 use Bolt\Collection\MutableBag;
 
 class MutableBagTest extends BagTest
@@ -12,5 +13,21 @@ class MutableBagTest extends BagTest
     protected function createBag($items = [])
     {
         return new MutableBag($items);
+    }
+
+    public function testRemovePath()
+    {
+        $bag = $this->createBag(
+            [
+                'items' => new ArrayObject(
+                    [
+                        'foo' => 'bar',
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertSame('bar', $bag->removePath('items/foo'));
+        $this->assertNull($bag->removePath('items/foo'));
     }
 }


### PR DESCRIPTION
Per special request of @GawainLynch 

For arrays:
```php
$data = [];
Arr::set($data, 'foo/bar', 'baz');

Arr::remove($data, 'foo/bar');
// => 'baz'
Arr::remove($data, 'foo/bar');
// => null
```
For bags:
```php
$bag = new MutableBag();
$bag->setPath('foo/bar', 'baz');

$bag->removePath('foo/bar');
// => 'baz'
$bag->removePath('foo/bar');
// => null
```