### PR TITLE
Added random methods

### DIFF
--- a/src/ImmutableBag.php
+++ b/src/ImmutableBag.php
@@ -479,6 +479,30 @@ class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSer
         }
     }
 
+    /**
+     * Returns a random value.
+     *
+     * @throws \InvalidArgumentException when the bag is empty
+     *
+     * @return mixed
+     */
+    public function randomValue()
+    {
+        return $this->randomValues(1)->first();
+    }
+
+    /**
+     * Returns a random key.
+     *
+     * @throws \InvalidArgumentException when the bag is empty
+     *
+     * @return mixed
+     */
+    public function randomKey()
+    {
+        return $this->randomKeys(1)->first();
+    }
+
     // endregion
 
     // region Methods returning a new bag
@@ -912,6 +936,39 @@ class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSer
     public function flatten($depth = 1)
     {
         return $this->createFrom(Arr::flatten($this->items, $depth));
+    }
+
+    /**
+     * Returns a bag with a random number of key/value pairs.
+     *
+     * @param int $size Number of pairs
+     *
+     * @throws \InvalidArgumentException when the bag is empty or the given $size is greater than the number of items
+     *
+     * @return static
+     */
+    public function randomValues($size)
+    {
+        $keys = $this->randomKeys($size);
+
+        return $keys->isEmpty() ? $keys : $this->pick($keys);
+    }
+
+    /**
+     * Returns a list with a random number of keys (as values).
+     *
+     * @param int $size Number of keys
+     *
+     * @throws \InvalidArgumentException when the bag is empty or the given $size is greater than the number of items
+     *
+     * @return static
+     */
+    public function randomKeys($size)
+    {
+        Assert::notEmpty($this->items, 'Cannot retrieve a random key/value for empty bags.');
+        Assert::range($size, 1, $this->count(), 'Expected $size to be between 1 and %3$s (the number of items in the bag). Got: %s');
+
+        return $this->createFrom((array) array_rand($this->items, $size));
     }
 
     // endregion

--- a/src/ImmutableBag.php
+++ b/src/ImmutableBag.php
@@ -928,14 +928,14 @@ class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSer
      *     $bag->pick('a', 'c');
      *     // => Bag of ['a' => 'red', 'c' => 'green']
      *
-     * @param string|string[]|int|int[] ...$keys The keys to keep
+     * @param iterable|string|string[]|int|int[] ...$keys The keys to keep
      *
      * @return static
      */
     public function pick($keys)
     {
         // Remove accepting array as first argument once destructuring arrays is supported (PHP 5.6)
-        return $this->intersectKeys(array_flip(is_iterable($keys) ? $keys : func_get_args()));
+        return $this->intersectKeys(array_flip(is_iterable($keys) ? Arr::from($keys) : func_get_args()));
     }
 
     /**
@@ -948,14 +948,14 @@ class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate, JsonSer
      *     $bag->omit('a', 'c');
      *     // => Bag of ['b' => 'blue']
      *
-     * @param string|string[]|int|int[] ...$keys The keys to remove
+     * @param iterable|string|string[]|int|int[] ...$keys The keys to remove
      *
      * @return static
      */
     public function omit($keys)
     {
         // Remove accepting array as first argument once destructuring arrays is supported (PHP 5.6)
-        return $this->diffKeys(array_flip(is_iterable($keys) ? $keys : func_get_args()));
+        return $this->diffKeys(array_flip(is_iterable($keys) ? Arr::from($keys) : func_get_args()));
     }
 
     /**

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -426,6 +426,40 @@ class ImmutableBagTest extends TestCase
         return [$bag, $matchBs, $b1, $b2];
     }
 
+    public function testRandomValue()
+    {
+        $bag = $this->createBag(['red']);
+
+        $this->assertSame('red', $bag->randomValue());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRandomValueEmpty()
+    {
+        $bag = $this->createBag([]);
+
+        $bag->randomValue();
+    }
+
+    public function testRandomKey()
+    {
+        $bag = $this->createBag(['red']);
+
+        $this->assertSame(0, $bag->randomKey());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRandomKeyEmpty()
+    {
+        $bag = $this->createBag([]);
+
+        $bag->randomKey();
+    }
+
     // endregion
 
     // region Methods returning a new bag

--- a/tests/ImmutableBagTest.php
+++ b/tests/ImmutableBagTest.php
@@ -790,6 +790,9 @@ class ImmutableBagTest extends TestCase
 
         $actual = $bag->pick(['a', 'c']);
         $this->assertBagResult(['a' => 'red', 'c' => 'green'], $bag, $actual);
+
+        $actual = $bag->pick($this->createBag(['a', 'c']));
+        $this->assertBagResult(['a' => 'red', 'c' => 'green'], $bag, $actual);
     }
 
     public function testOmit()
@@ -800,6 +803,9 @@ class ImmutableBagTest extends TestCase
         $this->assertBagResult(['b' => 'blue'], $bag, $actual);
 
         $actual = $bag->omit(['a', 'c']);
+        $this->assertBagResult(['b' => 'blue'], $bag, $actual);
+
+        $actual = $bag->omit($this->createBag(['a', 'c']));
         $this->assertBagResult(['b' => 'blue'], $bag, $actual);
     }
 


### PR DESCRIPTION
```php
$bag = Bag::from([
    'a' => 'red',
    'b' => 'blue',
    'c' => 'green',
]);

$bag->randomValue();
// => 'blue'

$bag->randomKey();
// => 'c'

$bag->randomValues(2);
// => Bag of ['a' => 'red', 'c' => 'green']

$bag->randomKeys(2);
// => Bag of ['b', 'c']
```

Note that the plural methods always return a bag even if the given size is 1.


-----


Also fixed a bug with `pick()` and `omit()`