### PR TITLE
[RFC] Added Bag::of() to create a bag from single items.

### DIFF
--- a/src/Bag.php
+++ b/src/Bag.php
@@ -37,6 +37,18 @@ class Bag implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
     }
 
     /**
+     * Creates a list from the arguments given.
+     *
+     * @param ...mixed $items
+     *
+     * @return static
+     */
+    public static function of()
+    {
+        return new static(func_get_args());
+    }
+
+    /**
      * Create a bag from a variety of collections.
      *
      * @param iterable|stdClass|null $collection

--- a/tests/BagTest.php
+++ b/tests/BagTest.php
@@ -19,6 +19,15 @@ class BagTest extends TestCase
 
     // region Creation / Unwrapping Methods
 
+    public function testOf()
+    {
+        /** @var Bag $cls */
+        $cls = $this->cls;
+        $bag = $cls::of('red', 'blue', []);
+
+        $this->assertSame(['red', 'blue', []], $bag->toArray());
+    }
+
     public function provideFromAndToArray()
     {
         return [


### PR DESCRIPTION
```php
Bag::of('red', 'blue');
// => Bag of ['red', 'blue']

Bag::of()
// => Empty Bag
```

I'm on the fence about whether this is useful. It's not that much different than `from`
```php
Bag::from(['red', 'blue']);
```
But with `from` you don't really know what the parameter is, so it is "a bag from _something_"
With `of`, you know what the items are so it reads a little better - "a bag of these items"