### PR TITLE
Arr::set fixes

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -309,13 +309,20 @@ class Arr
                 } else {
                     $current[$key] = $value;
                 }
-            } elseif (isset($current[$key])) {
-                if ($current instanceof Bag) {
-                    Deprecated::warn('Mutating items in a ' . Bag::class, 1.1, 'Use a ' . MutableBag::class . ' instead.');
-                }
 
-                $current = &$current[$key];
-            } elseif (!static::canReturnArraysByReference($current)) {
+                return;
+            }
+
+            if ($current instanceof Bag) {
+                Deprecated::warn('Mutating items in a ' . Bag::class, 1.1, 'Use a ' . MutableBag::class . ' instead.');
+            }
+
+            if (!isset($current[$key])) {
+                $current[$key] = [];
+            }
+
+            $next = null;
+            if ($current instanceof ArrayAccess && !static::canReturnArraysByReference($current, $key, $next)) {
                 throw new RuntimeException(
                     sprintf(
                         "Cannot set '%s', because '%s' is an %s which does not return arrays by reference from its offsetGet() method. See %s for an example of how to do this.",
@@ -325,14 +332,16 @@ class Arr
                         Bag::class
                     )
                 );
+            }
+            // If checking if object can return arrays by ref needed to fetch the value in the object then
+            // use that so we don't have to fetch the value again.
+            if ($next !== null) {
+                $current = &$next;
+                unset($next); // so assigning null above doesn't wipe out actual data
             } else {
-                if ($current instanceof Bag) {
-                    Deprecated::warn('Mutating items in a ' . Bag::class, 1.1, 'Use a ' . MutableBag::class . ' instead.');
-                }
-
-                $current[$key] = [];
                 $current = &$current[$key];
             }
+
             $invalidKey = $key;
         }
     }
@@ -553,66 +562,69 @@ class Arr
     }
 
     /**
-     * Determine whether the array/object can return arrays by reference.
+     * Determine whether the ArrayAccess object can return by reference.
      *
-     * @param ArrayAccess|array $obj
+     * @param ArrayAccess      $obj
+     * @param string           $key   The key to try with
+     * @param ArrayAccess|null $value The value if it needed to be fetched
      *
      * @return bool
      */
-    private static function canReturnArraysByReference($obj)
+    private static function canReturnArraysByReference(ArrayAccess $obj, $key, &$value)
     {
-        if (is_array($obj)) {
-            return true;
-        }
-
         static $supportedClasses = [
             // Add our classes by default to help with performance since we can
-            ImmutableBag::class => false,
-            Bag::class          => true, // but deprecated
-            MutableBag::class   => true,
+            Bag::class                     => true, // but deprecated
+            MutableBag::class              => true,
+
+            // These fail reflection check below even though they work fine :rolleyes:
+            \ArrayObject::class            => true,
+            \ArrayIterator::class          => true,
+            \RecursiveArrayIterator::class => true,
         ];
 
         $class = get_class($obj);
-        if (isset($supportedClasses[$class])) {
+
+        /*
+         * Check to see if offsetGet() is defined to return reference (with "&" before method name).
+         * This prevents us from triggering indirect modification notices.
+         * We know for sure that the method cannot return by reference if not defined correctly, so we cache false.
+         * We do not know for sure that the method can return by reference if it is defined correctly, so we cache
+         * null instead of true. This allows the reflection check to only happen once, but still drop through to
+         * validation below.
+         */
+        if (!isset($supportedClasses[$class])) {
+            $supportedClasses[$class] = (new \ReflectionMethod($obj, 'offsetGet'))->returnsReference() ? null : false;
+        }
+
+        // If definite value return that, else run validation below.
+        if ($supportedClasses[$class] !== null) {
             return $supportedClasses[$class];
         }
 
-        $testKey = '__reference_test';
-        $obj[$testKey] = [];
-        if (!defined('HHVM_VERSION')) {
-            $prev = set_error_handler('var_dump');
-            restore_error_handler();
-            set_error_handler(function ($type, $message, $file, $line) use ($prev, &$supportedClasses) {
-                $regex = '/Indirect modification of overloaded element of ([\w\\\\]+) has no effect/';
-                if (preg_match($regex, $message, $matches)) {
-                    $supportedClasses[$matches[1]] = false;
-                } elseif ($prev) {
-                    return call_user_func($prev, $type, $message, $file, $line);
-                } else {
-                    // return false to let PHP handle error
-                    return false;
-                }
-            });
-            try {
-                $test = &$obj[$testKey];
-                if (!isset($supportedClasses[$class])) {
-                    $supportedClasses[$class] = true;
-                }
-            } finally {
-                restore_error_handler();
-            }
-        } else {
-            $test1 = &$obj[$testKey];
-            $test2 = &$obj[$testKey];
-            $test1[$testKey] = 'test';
-            if ($test1 === $test2) {
-                $supportedClasses[$class] = true;
-                unset($test1[$testKey]);
-            } else {
-                $supportedClasses[$class] = false;
-            }
+        /*
+         * This could trigger a notice error if the offsetGet() method is defined to return reference
+         * but does not return a variable by reference. This is a logic error, but for performance we
+         * are not setting & removing an error handler for every key. The developer should have these
+         * being converted to an exception anyways or ignored for production.
+         */
+        $value1 = &$obj[$key];
+
+        // We cannot validate this result because objects are always returned by reference (and scalars do not matter).
+        if (!is_array($value1)) {
+            // return value (via parameter) so set() doesn't have to fetch the item again.
+            // We cannot do this if is an array because it will be the value instead of the reference.
+            $value = $value1;
+
+            return true;
         }
-        unset($obj[$testKey]);
+
+        // Verify the object can return arrays by reference.
+        $value2 = &$obj[$key];
+        $testKey = uniqid('__reference_test_');
+        $value1[$testKey] = 'test';
+        $supportedClasses[$class] = isset($value2[$testKey]);
+        unset($value1[$testKey]);
 
         return $supportedClasses[$class];
     }

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -330,7 +330,7 @@ class Arr
                         $path,
                         $invalidKey,
                         get_class($current),
-                        Bag::class
+                        MutableBag::class
                     ),
                     0,
                     $e

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -314,7 +314,7 @@ class Arr
                 return;
             }
 
-            if ($current instanceof Bag) {
+            if ($current instanceof Bag && !($current instanceof MutableBag)) {
                 Deprecated::warn('Mutating items in a ' . Bag::class, 1.1, 'Use a ' . MutableBag::class . ' instead.');
             }
 

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -6,6 +6,7 @@ use Bolt\Collection\Arr;
 use Bolt\Collection\Bag;
 use Bolt\Collection\Tests\Fixtures\TestArrayLike;
 use Bolt\Collection\Tests\Fixtures\TestBadArrayLike;
+use Bolt\Collection\Tests\Fixtures\TestBadLogicArrayLike;
 use Bolt\Collection\Tests\Fixtures\TestColumn;
 use PHPUnit\Framework\TestCase;
 
@@ -282,56 +283,43 @@ class ArrTest extends TestCase
         Arr::set($data, 'a/foo', 'bar');
     }
 
+    public function provideSetArraysReturnedByReferenceError()
+    {
+        return [
+            'bad definition' => [TestBadArrayLike::class],
+            'bad logic'      => [TestBadLogicArrayLike::class],
+        ];
+    }
+
     /**
+     * Test that Arr::set can determine which objects can return arrays by reference.
+     *
      * Test that Arr::set throws exception when trying to indirectly modify an ArrayAccess object.
-     * This happens when one tries to set a value on a sub array/object of an AA object.
-     * Ex: A/B/C where A is an object. B can be anything.
+     * This happens when one tries get a reference to an array inside an AA object.
+     * Ex: A/B/C where A is an AA object. B is an array.
+     *
+     * @dataProvider provideSetArraysReturnedByReferenceError
+     *
+     * @param string $cls
      */
-    public function testSetNestedIndirectModificationError()
+    public function testSetArraysReturnedByReferenceError($cls)
     {
         $data = [
-            'a' => new TestBadArrayLike(),
+            'a' => new $cls(),
         ];
 
-        $prevReporting = error_reporting(E_ALL);
-        $expectedErrorHandler = set_error_handler('var_dump');
-        restore_error_handler();
-
-        $errors = new \ArrayObject();
-        set_error_handler(function ($type, $message) use ($errors) {
-            $errors[] = [$type, $message];
-        });
-
+        $level = error_reporting(E_ALL & ~E_NOTICE);
         $e = null;
         try {
             Arr::set($data, 'a/foo/bar', 'baz');
         } catch (\Exception $e) {
         } catch (\Throwable $e) {
+            error_reporting($level);
         }
-        error_reporting($prevReporting);
-        restore_error_handler();
-
-        $actualErrorHandler = set_error_handler('var_dump');
-        restore_error_handler();
-
-        $message = 'Arr::set did not restore previous error handler';
-        if (is_array($expectedErrorHandler)) {
-            $this->assertInternalType('array', $actualErrorHandler, $message);
-            $this->assertSame($expectedErrorHandler[0], $actualErrorHandler[0], $message);
-            $this->assertSame($expectedErrorHandler[1], $actualErrorHandler[1], $message);
-        } else {
-            $this->assertSame($expectedErrorHandler, $actualErrorHandler, $message);
-        }
-
-        $this->assertArraySubset(
-            [[E_USER_NOTICE, 'Some notice']],
-            $errors->getArrayCopy(),
-            'Arr::set did not call previous error handler for non indirect modification errors'
-        );
 
         if ($e instanceof \RuntimeException) {
             $this->assertEquals(
-                "Cannot set 'a/foo/bar', because 'a' is an " . TestBadArrayLike::class .
+                "Cannot set 'a/foo/bar', because 'a' is an " . ltrim($cls, '\\') .
                 ' which does not return arrays by reference from its offsetGet() method. See ' . Bag::class .
                 ' for an example of how to do this.',
                 $e->getMessage()

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Collection\Tests;
 
 use Bolt\Collection\Arr;
 use Bolt\Collection\Bag;
+use Bolt\Collection\MutableBag;
 use Bolt\Collection\Tests\Fixtures\TestArrayLike;
 use Bolt\Collection\Tests\Fixtures\TestBadDefinitionArrayLike;
 use Bolt\Collection\Tests\Fixtures\TestBadLogicArrayLike;
@@ -320,7 +321,7 @@ class ArrTest extends TestCase
         if ($e instanceof \RuntimeException) {
             $this->assertEquals(
                 "Cannot set 'a/foo/bar', because 'a' is an " . ltrim($cls, '\\') .
-                ' which does not return arrays by reference from its offsetGet() method. See ' . Bag::class .
+                ' which does not return arrays by reference from its offsetGet() method. See ' . MutableBag::class .
                 ' for an example of how to do this.',
                 $e->getMessage()
             );

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -5,8 +5,9 @@ namespace Bolt\Collection\Tests;
 use Bolt\Collection\Arr;
 use Bolt\Collection\Bag;
 use Bolt\Collection\Tests\Fixtures\TestArrayLike;
-use Bolt\Collection\Tests\Fixtures\TestBadArrayLike;
+use Bolt\Collection\Tests\Fixtures\TestBadDefinitionArrayLike;
 use Bolt\Collection\Tests\Fixtures\TestBadLogicArrayLike;
+use Bolt\Collection\Tests\Fixtures\TestBadReferenceExpressionArrayLike;
 use Bolt\Collection\Tests\Fixtures\TestColumn;
 use PHPUnit\Framework\TestCase;
 
@@ -286,8 +287,9 @@ class ArrTest extends TestCase
     public function provideSetArraysReturnedByReferenceError()
     {
         return [
-            'bad definition' => [TestBadArrayLike::class],
+            'bad definition' => [TestBadDefinitionArrayLike::class],
             'bad logic'      => [TestBadLogicArrayLike::class],
+            'bad expression' => [TestBadReferenceExpressionArrayLike::class],
         ];
     }
 
@@ -308,13 +310,11 @@ class ArrTest extends TestCase
             'a' => new $cls(),
         ];
 
-        $level = error_reporting(E_ALL & ~E_NOTICE);
         $e = null;
         try {
             Arr::set($data, 'a/foo/bar', 'baz');
         } catch (\Exception $e) {
         } catch (\Throwable $e) {
-            error_reporting($level);
         }
 
         if ($e instanceof \RuntimeException) {

--- a/tests/Fixtures/TestBadArrayLike.php
+++ b/tests/Fixtures/TestBadArrayLike.php
@@ -4,11 +4,8 @@ namespace Bolt\Collection\Tests\Fixtures;
 
 class TestBadArrayLike extends TestArrayLike
 {
-    public function offsetGet($offset) // Note no "&"
+    public function offsetGet($offset) // Bad: no "&"
     {
-        // @codingStandardsIgnoreLine
-        @trigger_error('Some notice', E_USER_NOTICE);
-
         return $this->items[$offset];
     }
 }

--- a/tests/Fixtures/TestBadDefinitionArrayLike.php
+++ b/tests/Fixtures/TestBadDefinitionArrayLike.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Collection\Tests\Fixtures;
 
-class TestBadArrayLike extends TestArrayLike
+class TestBadDefinitionArrayLike extends TestArrayLike
 {
     public function offsetGet($offset) // Bad: no "&"
     {

--- a/tests/Fixtures/TestBadLogicArrayLike.php
+++ b/tests/Fixtures/TestBadLogicArrayLike.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bolt\Collection\Tests\Fixtures;
+
+class TestBadLogicArrayLike extends TestArrayLike
+{
+    public function &offsetGet($offset)
+    {
+        // Bad: value isn't assigned by reference
+        $value = $this->items[$offset];
+
+        return $value;
+    }
+}

--- a/tests/Fixtures/TestBadReferenceExpressionArrayLike.php
+++ b/tests/Fixtures/TestBadReferenceExpressionArrayLike.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Bolt\Collection\Tests\Fixtures;
+
+class TestBadReferenceExpressionArrayLike extends TestArrayLike
+{
+    public function &offsetGet($offset)
+    {
+        // Bad: Only variable references should be returned by reference
+        return isset($this->items[$offset]) ? $this->items[$offset] : null;
+    }
+}


### PR DESCRIPTION
- Fixed not throwing exception when object cannot return an array by reference for a pre-existing key
- Class' `offsetGet` is only called once per key now incase there is non-light logic in that method. It will be called twice for first value (per class) that is an array.
- Now it only gets a known key from an AA object and doesn't need to set a test value - in case only certain keys are allowed or removing is not allowed.
- Fixed false positives for incorrect logic in AA::offsetGet() methods. If returned item is an array we always get the item again and check if it is the same instance, instead of relying on warnings to be triggered.
- Fixed deprecation warnings not to trigger for `MutableBag`s.
- Fixed exception message to reference `MutableBag` instead of `Bag` for offsetGet example